### PR TITLE
Derive butcher struct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
+          - beta
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: beta
           override: true
       - uses: actions-rs/cargo@v1
         with:
@@ -43,8 +43,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
-          - 1.42.0
+          - beta
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -74,7 +73,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
+          - beta
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -93,7 +92,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
+          - beta
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -53,11 +53,9 @@ fn print_numbers(elems: Cow<[u32]>) {
 
 ### Minimum Supported Rust Version
 
-Currently, this crate requires at least rust toolchain version 1.42. CI is set
-up so that this rule is enforced.
-
-However, it is planned to use procedural macros that expand to expression, which
-will be available in rust version 1.45.
+This crate requires at least Rust 1.45. This is needed because the
+`butcher_struct` proc\_macro expands to an expression, which is implemented
+in Rust this version.
 
 #### License
 

--- a/butcher_proc_macro/src/butcher_struct.rs
+++ b/butcher_proc_macro/src/butcher_struct.rs
@@ -54,8 +54,8 @@ impl ButcheredStruct {
         quote! {
             (
                 #(
-                    #variables,
-                )*
+                    #variables
+                ),*
             )
         }
     }
@@ -76,8 +76,8 @@ impl ButcheredStruct {
         quote! {
             (
                 #(
-                    #variables,
-                )*
+                    #variables
+                ),*
             )
         }
     }
@@ -177,10 +177,10 @@ mod butchered_struct {
         let right = quote! {
             match foo {
                 std::borrow::Cow::Owned(Foo { a, .. }) => (
-                    ButcherFooa::from_owned(a),
+                    ButcherFooa::from_owned(a)
                 ),
                 std::borrow::Cow::Borrowed(Foo { a, .. }) => (
-                    ButcherFooa::from_borrowed(a),
+                    ButcherFooa::from_borrowed(a)
                 ),
             }
         };
@@ -198,7 +198,7 @@ mod butchered_struct {
         let left = tmp.owned_arm();
         let right = quote! {
             std::borrow::Cow::Owned(Foo { a, .. }) => (
-                ButcherFooa::from_owned(a),
+                ButcherFooa::from_owned(a)
             ),
         };
 
@@ -215,7 +215,7 @@ mod butchered_struct {
         let left = tmp.owned_return_expr();
         let right = quote! {
             (
-                ButcherFooa::from_owned(a),
+                ButcherFooa::from_owned(a)
             )
         };
 
@@ -232,7 +232,7 @@ mod butchered_struct {
         let left = tmp.borrowed_arm();
         let right = quote! {
             std::borrow::Cow::Borrowed(Foo { a, .. }) => (
-                ButcherFooa::from_borrowed(a),
+                ButcherFooa::from_borrowed(a)
             ),
         };
 
@@ -251,7 +251,7 @@ mod butchered_struct {
         let right = quote! {
             (
                 ButcherFooa::from_borrowed(a),
-                ButcherFoob::from_borrowed(b),
+                ButcherFoob::from_borrowed(b)
             )
         };
 

--- a/butcher_proc_macro/src/derive_butcher.rs
+++ b/butcher_proc_macro/src/derive_butcher.rs
@@ -210,6 +210,7 @@ impl Field {
         let phantom = phantom();
 
         quote! {
+            #[allow(non_camel_case_types)]
             #vis struct #struct_with_generics
                 (
                     #phantom< ( #( #types_in_phantom, )* ) > ,
@@ -709,6 +710,7 @@ mod field {
         let bs = ButcheredStruct::from(s).unwrap();
         let left = bs.fields[0].associated_struct_declaration(&bs.name);
         let right = quote! {
+            #[allow(non_camel_case_types)]
             struct ButcherFooa<>(
                 std::marker::PhantomData<()>,
                 std::marker::PhantomData<()>,
@@ -725,6 +727,7 @@ mod field {
         let bs = ButcheredStruct::from(s).unwrap();
         let left = bs.fields[0].associated_struct_declaration(&bs.name);
         let right = quote! {
+            #[allow(non_camel_case_types)]
             struct ButcherFooa<T,>(
                 std::marker::PhantomData<(T,)>,
                 std::marker::PhantomData<()>,
@@ -741,6 +744,7 @@ mod field {
         let bs = ButcheredStruct::from(s).unwrap();
         let left = bs.fields[0].associated_struct_declaration(&bs.name);
         let right = quote! {
+            #[allow(non_camel_case_types)]
             struct ButcherFooa<'a,>(
                 std::marker::PhantomData<()>,
                 std::marker::PhantomData<(&'a (),)>,
@@ -757,6 +761,7 @@ mod field {
         let bs = ButcheredStruct::from(s).unwrap();
         let left = bs.fields[0].associated_struct_declaration(&bs.name);
         let right = quote! {
+            #[allow(non_camel_case_types)]
             struct ButcherFooa<'a, T,>(
                 std::marker::PhantomData<(T,)>,
                 std::marker::PhantomData<(&'a (),)>,

--- a/butcher_proc_macro/src/derive_butcher.rs
+++ b/butcher_proc_macro/src/derive_butcher.rs
@@ -36,21 +36,19 @@ pub enum DeriveError {
 impl Display for DeriveError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            DeriveError::FoundUnion => format_args!("Butcher does not support unions"),
-            DeriveError::FoundUnitStruct => format_args!("Butchering is useless for unit structs"),
-            DeriveError::FoundEnum => format_args!(
+            DeriveError::FoundUnion => "Butcher does not support unions",
+            DeriveError::FoundUnitStruct => "Butchering is useless for unit structs",
+            DeriveError::FoundEnum => {
                 "Butcher currently does not support enums. This is planned for next release"
-            ),
-            DeriveError::FoundTupledStruct => {
-                format_args!("Butcher does not currently support tupled structs")
             }
+            DeriveError::FoundTupledStruct => "Butcher does not currently support tupled structs",
             DeriveError::MultipleButcheringMethod => {
-                format_args!("Multiple butchering method provided. Choose one!")
+                "Multiple butchering method provided. Choose one!"
             }
-            DeriveError::FoundImplTrait => format_args!("Butcher does not support impl Trait"),
-            DeriveError::FoundMacroAsType => format_args!("Butcher does not support macro as type"),
-            DeriveError::FoundTraitObject => format_args!("Butcher does not support trait objects"),
-            DeriveError::UnknownMethod => format_args!("Unknown butchering method"),
+            DeriveError::FoundImplTrait => "Butcher does not support impl Trait",
+            DeriveError::FoundMacroAsType => "Butcher does not support macro as type",
+            DeriveError::FoundTraitObject => "Butcher does not support trait objects",
+            DeriveError::UnknownMethod => "Unknown butchering method",
         }
         .fmt(f)
     }

--- a/butcher_proc_macro/src/derive_butcher.rs
+++ b/butcher_proc_macro/src/derive_butcher.rs
@@ -12,9 +12,11 @@ use syn::{
     TypeTuple, Visibility,
 };
 
-use quote::{format_ident, quote, ToTokens};
+use quote::{quote, ToTokens};
 
 use proc_macro2::TokenStream;
+
+use crate::utils;
 
 #[derive(Debug, PartialEq)]
 pub enum DeriveError {
@@ -228,7 +230,7 @@ impl Field {
     }
 
     fn associated_struct_name(&self, main_struct_name: &Ident) -> Ident {
-        format_ident!("Butcher{}{}", main_struct_name, self.name)
+        utils::associated_struct_name(main_struct_name, &self.name)
     }
 
     fn associated_lifetimes_in_phantom(&self) -> impl Iterator<Item = impl ToTokens> + '_ {

--- a/butcher_proc_macro/src/lib.rs
+++ b/butcher_proc_macro/src/lib.rs
@@ -22,7 +22,6 @@ macro_rules! assert_eq_tt {
 mod butcher_struct;
 
 // TODO: remove this, actually use this dead code
-#[allow(dead_code)]
 mod derive_butcher;
 
 #[proc_macro]
@@ -35,7 +34,7 @@ pub fn butcher_struct(tokens: TokenStream) -> TokenStream {
     data.expand_to_code().into()
 }
 
-#[proc_macro_derive(Butcher)]
+#[proc_macro_derive(Butcher, attributes(butcher))]
 pub fn butcher_derive(tokens: TokenStream) -> TokenStream {
     let data = parse_macro_input!(tokens as DeriveInput);
     derive_butcher::ButcheredStruct::from(data)

--- a/butcher_proc_macro/src/lib.rs
+++ b/butcher_proc_macro/src/lib.rs
@@ -5,18 +5,10 @@ use crate::butcher_struct::ButcheredStruct;
 use proc_macro::TokenStream;
 use syn::{parse_macro_input, DeriveInput};
 
-#[cfg(test)]
-macro_rules! assert_eq_tt {
-    ($left: ident, $right: ident) => {
-        let left = format!("{}", $left);
-        let right = format!("{}", $right);
-
-        assert_eq!(left, right);
-    };
-}
+#[macro_use]
+mod utils;
 
 mod butcher_struct;
-
 mod derive_butcher;
 
 #[proc_macro]

--- a/butcher_proc_macro/src/lib.rs
+++ b/butcher_proc_macro/src/lib.rs
@@ -3,11 +3,7 @@ extern crate proc_macro;
 use crate::butcher_struct::ButcheredStruct;
 
 use proc_macro::TokenStream;
-use proc_macro2::TokenStream as TokenStream2;
-use quote::quote;
 use syn::{parse_macro_input, DeriveInput};
-
-use syn::Error;
 
 #[cfg(test)]
 macro_rules! assert_eq_tt {
@@ -21,7 +17,6 @@ macro_rules! assert_eq_tt {
 
 mod butcher_struct;
 
-// TODO: remove this, actually use this dead code
 mod derive_butcher;
 
 #[proc_macro]
@@ -39,12 +34,6 @@ pub fn butcher_derive(tokens: TokenStream) -> TokenStream {
     let data = parse_macro_input!(tokens as DeriveInput);
     derive_butcher::ButcheredStruct::from(data)
         .map(derive_butcher::ButcheredStruct::expand_to_code)
-        .unwrap_or_else(to_compile_errors)
+        .unwrap_or_else(|e| e.to_compile_error())
         .into()
-}
-
-fn to_compile_errors(i: Vec<Error>) -> TokenStream2 {
-    let i = i.iter().map(syn::Error::to_compile_error);
-
-    quote! { #( #i )* }
 }

--- a/butcher_proc_macro/src/utils.rs
+++ b/butcher_proc_macro/src/utils.rs
@@ -1,0 +1,32 @@
+use syn::Ident;
+
+use quote::format_ident;
+
+#[cfg(test)]
+macro_rules! assert_eq_tt {
+    ($left: ident, $right: ident) => {
+        let left = format!("{}", $left);
+        let right = format!("{}", $right);
+
+        assert_eq!(left, right);
+    };
+}
+
+pub(crate) fn associated_struct_name(main_struct: &Ident, field: &Ident) -> Ident {
+    format_ident!("Butcher{}{}", main_struct, field)
+}
+
+#[cfg(test)]
+mod associated_struct_name {
+    use super::*;
+
+    use syn::parse_quote;
+
+    #[test]
+    fn test() {
+        let main: Ident = parse_quote! { Foo };
+        let field: Ident = parse_quote! { bar };
+
+        assert_eq!(associated_struct_name(&main, &field), "ButcherFoobar");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@
 //!
 //! #[derive(Butcher, Clone)]
 //! struct Book {
-//!     #[butcher(as_ref)]
+//!     #[butcher(flatten)]
 //!     title: String,
 //!     #[butcher(copy)]
 //!     id: usize,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,16 +21,20 @@
 //! use std::borrow::Cow;
 //! use butcher::butcher_struct;
 //!
-//! #[derive(Clone)]
+//! use butcher::{Butcher, ButcherField};
+//!
+//! #[derive(Butcher, Clone)]
 //! struct Book {
+//!     #[butcher(as_ref)]
 //!     title: String,
+//!     #[butcher(copy)]
 //!     id: usize,
 //!     author: Box<str>,
 //!     // An useless field
 //!     is_opened: bool,
 //! }
 //!
-//! fn destructure_book(b: Cow<Book>) -> (Cow<usize>, Cow<String>, Cow<Box<str>>) {
+//! fn destructure_book(b: Cow<Book>) -> (usize, Cow<str>, Cow<Box<str>>) {
 //!     butcher_struct!(b: Book, id, title, author)
 //! }
 //! ```
@@ -59,50 +63,6 @@
 
 pub mod iterator;
 
-// This is blocked by issue #54727. See it on github:
-// https://github.com/rust-lang/rust/issues/54727
-//
-// As such, we have to switch to a hand-made declarative macro.
-// pub use butcher_proc_macro::butcher_struct;
-
-#[macro_export]
-macro_rules! butcher_struct {
-    {
-        $var_name: ident : $ty: ident,
-        $( $field: ident ),+ $(,)?
-    } => {{
-        use std::borrow::Cow;
-        match $var_name {
-            Cow::Owned($ty {
-                $(
-                    $field,
-                )+
-                ..
-            }) => (
-                $(
-                    Cow::Owned($field),
-                )+
-            ),
-            Cow::Borrowed($ty {
-                $(
-                    $field,
-                )+
-                ..
-            }) => (
-                $(
-                    Cow::Borrowed($field),
-                )+
-            ),
-        }
-    }};
-
-    {
-        $var_name: ident : $ty: ident $( , )?
-    } => {
-        compile_error!("This non-distructuring is equivalent of a Drop. Use this function instead.");
-    }
-}
-
 pub use butcher_proc_macro::*;
 
 pub use butcher_core::ButcherField;
@@ -119,7 +79,7 @@ mod derive_butcher {
         struct Foo<'a, T> {
             #[butcher(copy)]
             first: usize,
-            #[butcher(deref, T: Clone)]
+            #[butcher(unbox)]
             second: Box<T>,
             #[butcher(copy)]
             third: &'a usize,
@@ -127,12 +87,36 @@ mod derive_butcher {
             fourth: T,
             #[butcher(regular, T: Clone)]
             fifth: T,
-            #[butcher(as_ref)]
+            #[butcher(flatten)]
             sixth: String,
             #[butcher(copy, T: 'a)]
             seventh: &'a T,
-            #[butcher(as_ref, T: Clone)]
+            #[butcher(flatten, T: Clone)]
             eighth: Vec<T>,
+        }
+    }
+
+    mod struct_butchering {
+        use super::*;
+
+        use std::borrow::Cow;
+
+        #[allow(dead_code)]
+        #[derive(Butcher, Clone)]
+        struct Book {
+            #[butcher(flatten)]
+            title: String,
+            #[butcher(copy)]
+            id: usize,
+            #[butcher(flatten)]
+            author: Box<str>,
+            // An useless field
+            is_opened: bool,
+        }
+
+        #[allow(dead_code)]
+        fn destructure_book(b: Cow<Book>) -> (usize,) {
+            butcher_struct!(b: Book, id)
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,3 +102,37 @@ macro_rules! butcher_struct {
         compile_error!("This non-distructuring is equivalent of a Drop. Use this function instead.");
     }
 }
+
+pub use butcher_proc_macro::*;
+
+pub use butcher_core::ButcherField;
+
+#[cfg(test)]
+mod derive_butcher {
+    use super::*;
+
+    mod r#struct {
+        use super::*;
+
+        #[allow(dead_code)]
+        #[derive(Butcher)]
+        struct Foo<'a, T> {
+            #[butcher(copy)]
+            first: usize,
+            #[butcher(deref, T: Clone)]
+            second: Box<T>,
+            #[butcher(copy)]
+            third: &'a usize,
+            #[butcher(copy, T: Clone)]
+            fourth: T,
+            #[butcher(regular, T: Clone)]
+            fifth: T,
+            #[butcher(as_ref)]
+            sixth: String,
+            #[butcher(copy, T: 'a)]
+            seventh: &'a T,
+            #[butcher(as_ref, T: Clone)]
+            eighth: Vec<T>,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ mod derive_butcher {
         }
 
         #[allow(dead_code)]
-        fn destructure_book(b: Cow<Book>) -> (usize,) {
+        fn destructure_book(b: Cow<Book>) -> usize {
             butcher_struct!(b: Book, id)
         }
     }


### PR DESCRIPTION
Adds a proper `derive(Butcher)` macro, which, combined with the `butcher_struct` macro, allows simple destructing.