### PR TITLE
Implement the rebutcher butchering method

### DIFF
--- a/butcher/src/deriving_butcher_struct.rs
+++ b/butcher/src/deriving_butcher_struct.rs
@@ -153,6 +153,14 @@
 //!
 //! See the documentation for [`Unbox`] for more information.
 //!
+//! ## Rebutcher
+//!
+//! Sometimes it is necessary to butcher again a field of a butchered struct.
+//! This is what rebutcher does. This can be helpfull when it is necessay to
+//! destructure/pattern match on a struct contained in another struct.
+//!
+//! See the documentation for [`Rebutcher`] for more information.
+//!
 //! ## Fixing triggered compilation errors
 //!
 //! While this proc macro generally generates code that compile on the first
@@ -205,7 +213,8 @@
 //! [`Clone`]: https://doc.rust-lang.org/std/clone/trait.Clone.html
 //! [`Box`]: https://doc.rust-lang.org/std/boxed/struct.Box.html
 //! [`WhereClauseItem`]: https://doc.rust-lang.org/reference/items/generics.html#where-clauses
-//! [`Regular`]: ../methods/struct.Regular.html
 //! [`Copy`]: ../methods/struct.Copy.html
 //! [`Flatten`]: ../methods/struct.Flatten.html
+//! [`Rebutcher`]: ../methods/struct.Rebutcher.html
+//! [`Regular`]: ../methods/struct.Regular.html
 //! [`Unbox`]: ../methods/struct.Unbox.html

--- a/butcher/src/methods.rs
+++ b/butcher/src/methods.rs
@@ -228,15 +228,3 @@ where
         <Self::Method as ButcheringMethod<'cow, T>>::from_borrowed(i)
     }
 }
-
-/*
-use crate::Butcher;
-
-#[derive(Butcher, Clone)]
-struct Foo {
-    #[butcher(rebutcher)]
-    bar: Bar,
-}
-#[derive(Butcher, Clone)]
-struct Bar(usize);
-*/


### PR DESCRIPTION
This butchering method can be applied to any field whose type implements Butcher.
When Butcher is called on the struct/enum, Butcher will also be called for that
field. This allows nested pattern matching, as reported in issue #9 [1].

This should fix #9.

[1]: https://github.com/scileo/butcher/issues/9