### PR TITLE
Flatten implementation

### DIFF
--- a/butcher/src/flatten.rs
+++ b/butcher/src/flatten.rs
@@ -1,0 +1,64 @@
+//! Allows to flatten some data wrapped in a `Cow`.
+//!
+//! For instance, this allows to convert a `Cow<String>` to a `Cow<str>`, which
+//! is easier to deal with.
+
+use std::borrow::Cow;
+use std::ops::Deref;
+
+// TODO: add doc
+fn flatten_cow<'cow, T>(input: Cow<'cow, T>) -> Cow<'cow, <T as Deref>::Target>
+where
+    T: Deref + ToOwned,
+    <T as Deref>::Target: ToOwned,
+    <<T as Deref>::Target as ToOwned>::Owned: From<<T as ToOwned>::Owned>,
+{
+    match input {
+        Cow::Borrowed(input) => Cow::Borrowed(input.deref()),
+        Cow::Owned(input) => Cow::Owned(input.into()),
+    }
+}
+
+// TODO: add doc
+pub trait FlattenCow<'cow, T>
+where
+    T: Deref,
+    <T as Deref>::Target: ToOwned,
+{
+    fn flatten(self) -> Cow<'cow, <T as Deref>::Target>;
+}
+
+impl<'cow, T> FlattenCow<'cow, T> for Cow<'cow, T>
+where
+    T: Deref + ToOwned,
+    <T as Deref>::Target: ToOwned,
+    <<T as Deref>::Target as ToOwned>::Owned: From<<T as ToOwned>::Owned>,
+{
+    fn flatten(self) -> Cow<'cow, <T as Deref>::Target> {
+        flatten_cow(self)
+    }
+}
+
+#[cfg(test)]
+mod flatten_fn {
+    use super::*;
+
+    #[test]
+    fn flatten_cow_string_owned() {
+        let input: Cow<String> = Cow::Owned(String::from("foo"));
+        let output: Cow<str> = flatten_cow(input);
+
+        assert!(matches!(output, Cow::Owned(_)));
+        assert_eq!(output, "foo");
+    }
+
+    #[test]
+    fn flatten_cow_string_borrowed() {
+        let tmp = String::from("bar");
+        let input: Cow<String> = Cow::Borrowed(&tmp);
+        let output: Cow<str> = flatten_cow(input);
+
+        assert!(matches!(output, Cow::Borrowed(_)));
+        assert_eq!(output, "bar");
+    }
+}

--- a/butcher/src/flatten.rs
+++ b/butcher/src/flatten.rs
@@ -61,4 +61,23 @@ mod flatten_fn {
         assert!(matches!(output, Cow::Borrowed(_)));
         assert_eq!(output, "bar");
     }
+
+    #[test]
+    fn flatten_cow_box_str_owned() {
+        let input: Cow<Box<str>> = Cow::Owned(Box::from("foo"));
+        let output: Cow<str> = flatten_cow(input);
+
+        assert!(matches!(output, Cow::Owned(_)));
+        assert_eq!(output, "foo");
+    }
+
+    #[test]
+    fn flatten_cow_box_str_borrowed() {
+        let tmp = Box::from("bar");
+        let input: Cow<Box<str>> = Cow::Borrowed(&tmp);
+        let output: Cow<str> = flatten_cow(input);
+
+        assert!(matches!(output, Cow::Borrowed(_)));
+        assert_eq!(output, "bar");
+    }
 }

--- a/butcher/src/flatten.rs
+++ b/butcher/src/flatten.rs
@@ -6,7 +6,6 @@
 use std::borrow::Cow;
 use std::ops::Deref;
 
-// TODO: add doc
 fn flatten_cow<T>(input: Cow<T>) -> Cow<<T as Deref>::Target>
 where
     T: Deref + ToOwned,
@@ -19,7 +18,49 @@ where
     }
 }
 
-// TODO: add doc
+/// Allows to flatten some data wrapped in a `Cow`.
+///
+/// The best use case for this is to transform a `Cow<String>` into a
+/// `Cow<str>`. This also works for the boxed unsized type, as long as they
+/// implement the traits as required below.
+///
+/// # Example
+///
+/// The following example shows the flattening of `Cow<String>` and
+/// `Cow<PathBuf>`:
+///
+/// ```rust
+/// use std::{
+///     borrow::Cow,
+///     path::{Path, PathBuf},
+/// };
+///
+/// use butcher::flatten::FlattenCow;
+///
+/// // The type is annotated so that it is easier to understand what's happening
+/// let a: Cow<String> = Cow::Owned(String::from("Grace Hopper"));
+/// let a_flattened: Cow<str> = a.flatten();
+/// assert_eq!(a_flattened, "Grace Hopper");
+///
+/// let b: Cow<PathBuf> = Cow::Owned(PathBuf::from("/path/to/foo"));
+/// let b_flattened: Cow<Path> = b.flatten();
+/// assert_eq!(b_flattened, Path::new("/path/to/foo"));
+/// ```
+///
+/// # Traits requirements
+///
+/// In order to call `flatten` on a `Cow<T>`, the following requirements must be
+/// satisified:
+///   - `T` must implement [`ToOwned`], which is required to build the initial
+///   `Cow<T>`,
+///   - `T` must implement [`Deref`], and its `Target` must also implement
+///   [`ToOwned`], which is required to build the output
+///   `Cow<<T as Deref>::Target>`, and when the borrowed case is met,
+///   - `T` must be convertible into the `Owned` type associated to the `Target`
+///   dereferenced type, which is required when the owned case is met.
+///
+/// [`ToOwned`]: https://doc.rust-lang.org/std/borrow/trait.ToOwned.html
+/// [`Deref`]: https://doc.rust-lang.org/std/ops/trait.Deref.html
 pub trait FlattenCow<'cow, T>
 where
     T: Deref,

--- a/butcher/src/flatten.rs
+++ b/butcher/src/flatten.rs
@@ -7,7 +7,7 @@ use std::borrow::Cow;
 use std::ops::Deref;
 
 // TODO: add doc
-fn flatten_cow<'cow, T>(input: Cow<'cow, T>) -> Cow<'cow, <T as Deref>::Target>
+fn flatten_cow<T>(input: Cow<T>) -> Cow<<T as Deref>::Target>
 where
     T: Deref + ToOwned,
     <T as Deref>::Target: ToOwned,

--- a/butcher/src/lib.rs
+++ b/butcher/src/lib.rs
@@ -66,10 +66,10 @@
 
 pub mod deriving_butcher_enum;
 pub mod deriving_butcher_struct;
-pub mod unnest;
+pub mod flatten;
 pub mod iterator;
 pub mod methods;
-pub mod flatten;
+pub mod unnest;
 
 pub use butcher_proc_macro::*;
 

--- a/butcher/src/lib.rs
+++ b/butcher/src/lib.rs
@@ -66,7 +66,7 @@
 
 pub mod deriving_butcher_enum;
 pub mod deriving_butcher_struct;
-pub mod flatten;
+pub mod unnest;
 pub mod iterator;
 pub mod methods;
 

--- a/butcher/src/lib.rs
+++ b/butcher/src/lib.rs
@@ -69,6 +69,7 @@ pub mod deriving_butcher_struct;
 pub mod unnest;
 pub mod iterator;
 pub mod methods;
+pub mod flatten;
 
 pub use butcher_proc_macro::*;
 

--- a/butcher/src/unnest.rs
+++ b/butcher/src/unnest.rs
@@ -1,9 +1,9 @@
-//! A trait that allows to flatten `Cow<Cow<T>>` to `Cow<T>`.
+//! A trait that allows to unnest `Cow<Cow<T>>` to `Cow<T>`.
 
 use std::borrow::Cow;
 use std::ops::Deref;
 
-fn flatten_cow<'a, 'b, T>(this: Cow<'a, Cow<'b, T>>) -> Cow<'a, T>
+fn unnest_cow<'a, 'b, T>(this: Cow<'a, Cow<'b, T>>) -> Cow<'a, T>
 where
     'b: 'a,
     T: ToOwned + 'b,
@@ -14,10 +14,10 @@ where
     }
 }
 
-/// Allows to flatten a `Cow`.
+/// Allows to unnest a `Cow`.
 ///
 /// This trait is automatically implemented for each `Cow<Cow<T>>`, and provide
-/// the `flatten` method. This method allows to deal easily with return type
+/// the `unnest` method. This method allows to deal easily with return type
 /// created by `#[derive(Butcher)]` when it is called on objects with `Cow` in
 /// one of their fields.
 ///
@@ -36,14 +36,14 @@ where
 /// Here, the fields `bar` of `ButcheredFoo` would have type
 /// `Cow<'cow<Cow<'a str>>`. This trait allows us to easily get back a
 /// `Cow<'cow str>`.
-pub trait FlattenCow<'a, T: ToOwned + 'a> {
-    fn flatten(self) -> Cow<'a, T>;
+pub trait UnnestCow<'a, T: ToOwned + 'a> {
+    fn unnest(self) -> Cow<'a, T>;
 }
 
-impl<'a, 'b: 'a, T: ToOwned + 'a> FlattenCow<'a, T> for Cow<'b, Cow<'a, T>> {
+impl<'a, 'b: 'a, T: ToOwned + 'a> UnnestCow<'a, T> for Cow<'b, Cow<'a, T>> {
     /// Flattens the `Cow`.
-    fn flatten(self) -> Cow<'a, T> {
-        flatten_cow(self)
+    fn unnest(self) -> Cow<'a, T> {
+        unnest_cow(self)
     }
 }
 
@@ -58,7 +58,7 @@ mod tests {
     #[test]
     fn owned_owned() {
         let input: Cow<Cow<usize>> = Cow::Owned(Cow::Owned(42));
-        let tmp = input.flatten();
+        let tmp = input.unnest();
 
         assert_eq!(tmp, Cow::Owned(42));
         assert!(is_owned(tmp));
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn owned_borrowed() {
         let input: Cow<Cow<usize>> = Cow::Owned(Cow::Borrowed(&42));
-        let tmp = input.flatten();
+        let tmp = input.unnest();
 
         assert_eq!(tmp, Cow::Owned(42));
         assert!(!is_owned(tmp));
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn borrowed_owned() {
         let input: Cow<Cow<usize>> = Cow::Borrowed(&Cow::Owned(42));
-        let tmp = input.flatten();
+        let tmp = input.unnest();
 
         assert_eq!(tmp, Cow::Owned(42));
         assert!(!is_owned(tmp));
@@ -85,7 +85,7 @@ mod tests {
     #[test]
     fn borrowed_borrowed() {
         let input: Cow<Cow<usize>> = Cow::Borrowed(&Cow::Borrowed(&42));
-        let tmp = input.flatten();
+        let tmp = input.unnest();
 
         assert_eq!(tmp, Cow::Owned(42));
         assert!(!is_owned(tmp));


### PR DESCRIPTION
This PR adds the renames `FlattenCow` trait to `UnnestCow`, and creates the `FlattenCow` trait which is responsible to convert for instance `Cow<String>` to `Cow<str>`.

In more general terms, `FlattenCow` provides a method for conversion from `Cow<T>` to `Cow<<T as Deref>::Target>`. It uses the `Deref` method for the borrowed case (for instance: `&String` to `&str`), and the `From` trait for the owned case. The later method allows us to 

This fixes #8.