### PR TITLE
CI: tweak versions used for various tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.42.0
+          - 1.40.0
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.42.0
+          - 1.40.0
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
     strategy:
       matrix:
         rust:
+          - 1.42.0
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -23,6 +24,7 @@ jobs:
       - uses: actions-rs/cargo@v1
         with:
           command: check
+          args: --tests
 
   test-features:
     name: Test Suite
@@ -30,6 +32,7 @@ jobs:
     strategy:
       matrix:
         rust:
+          - 1.42.0
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -67,7 +70,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - stable
+          - nightly
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.40.0
+          - 1.42.0
           - stable
     steps:
       - uses: actions/checkout@v1
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         rust:
-          - 1.40.0
+          - 1.42.0
           - stable
     steps:
       - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -102,8 +102,9 @@ fn print_numbers(elems: Cow<[u32]>) {
 
 ### Minimum Supported Rust Version
 
-This crate currently compiles on rust version 1.45. It may be compatible with
-older versions of rust, but this is currently not guaranteed
+This crate compiles in rust 1.42 and older. Upgrading MSRV is a breaking change.
+CI is set up so that it guarantees that the crate compiles and tests pass on
+both 1.42 and stable rust.
 
 #### License
 


### PR DESCRIPTION
Now 1.42 and stable are used for both check and tests. Clippy uses the nightly
toolchain.

~It is not sure that 1.42 is recent enough. The next commit will try for determine
it.~

Edit: 1.42 is the oldest version of rust that compile and tests butcher.