### PR TITLE
Implement the unbutcher functionality

### DIFF
--- a/butcher/src/deriving_butcher_enum.rs
+++ b/butcher/src/deriving_butcher_enum.rs
@@ -53,3 +53,35 @@
 //!     Bar(T),
 //! }
 //! ```
+//!
+//! Unbutchering can be used to create simple catch-all match arm:
+//!
+//! ```rust
+//! # fn handle_special_event(_: LogEvent) {}
+//! use butcher::Butcher;
+//! use std::borrow::Cow;
+//!
+//! #[derive(Debug, Clone, Butcher)]
+//! enum LogEvent {
+//!     Info,
+//!     Dbg(&'static str),
+//!     Warning(
+//!         #[butcher(flatten)]
+//!         String,
+//!     ),
+//! }
+//!
+//! let event: Cow<LogEvent> = Cow::Owned(LogEvent::Dbg("Heyo"));
+//!
+//! match LogEvent::butcher(event) {
+//!     ButcheredLogEvent::Info => {},
+//!     ButcheredLogEvent::Warning(w) => println!("Warning emitted: {}", w),
+//!     // A catch-all match arm
+//!     other => {
+//!         // We get back the original data
+//!         let e = LogEvent::unbutcher(other);
+//!
+//!         handle_special_event(e);
+//!     }
+//! }
+//! ```

--- a/butcher/src/deriving_butcher_struct.rs
+++ b/butcher/src/deriving_butcher_struct.rs
@@ -161,6 +161,45 @@
 //!
 //! See the documentation for [`Rebutcher`] for more information.
 //!
+//! ## Retrieving the initial input type
+//!
+//! The `unbutcher` allows to retrieve the initial data, in its owned form.
+//! It will move the associated butchered struct, and return the initial struct.
+//! Every borrowed data will be cloned if necessary.
+//!
+//! This is particularly usefull when a catch-all match arm is needed.
+//!
+//! ```rust
+//! # #[derive(Butcher, Clone)]
+//! # struct Client {
+//! #     #[butcher(flatten)]
+//! #     name: String,
+//! #     #[butcher(copy)]
+//! #     age: u8,
+//! # }
+//! use butcher::Butcher;
+//! use std::borrow::Cow;
+//!
+//! let c_in_cow: Cow<Client> = Cow::Owned(Client {
+//!     name: "Alan Turing".to_string(),
+//!     age: 41,
+//! });
+//!
+//! match Client::butcher(c_in_cow) {
+//!     ButcheredClient { name, age } if name.as_ref() == "Abdul Alhazred" => {
+//!         println!("Necronomicon author detected!")
+//!     },
+//!     ButcheredClient { name, age } if age == 255 => {
+//!         println!("This person will soon reborn")
+//!     },
+//!     other => {
+//!         // other has type ButcheredClient. Let's convert it to Client:
+//!         let other = Client::unbutcher(other);
+//!         println!("Hello {}", other.name);
+//!     },
+//! }
+//! ```
+//!
 //! ## Fixing triggered compilation errors
 //!
 //! While this proc macro generally generates code that compile on the first

--- a/butcher/src/lib.rs
+++ b/butcher/src/lib.rs
@@ -87,4 +87,6 @@ pub trait Butcher<'cow>: ToOwned + 'cow {
     type Output: 'cow;
 
     fn butcher(this: Cow<'cow, Self>) -> Self::Output;
+
+    fn unbutcher(this: Self::Output) -> Self;
 }


### PR DESCRIPTION
This PR implements the `unbutcher` associated function for `Butcher`, `ButcheringMethod`, and `ButcherField`. Its goal is to do the exact reverse operation of `butcher`, cloning non-owned data.

This allows to simply convert catch-all match pattern back into the original type.

Fix #10.